### PR TITLE
Remove PermGen configuration

### DIFF
--- a/openmrs-server/Dockerfile
+++ b/openmrs-server/Dockerfile
@@ -14,7 +14,7 @@ RUN sed -i '/Connector port="8080"/a URIEncoding="UTF-8" relaxedPathChars="[]|" 
 # for clarity.  These list the variables supported, and the default values if not overridden
 
 # These environment variables are appended to configure the Tomcat JAVA_OPTS
-ENV OMRS_JAVA_MEMORY_OPTS="-Xmx2048m -Xms1024m -XX:PermSize=256m -XX:MaxPermSize=512m -XX:NewSize=128m"
+ENV OMRS_JAVA_MEMORY_OPTS="-Xmx2048m -Xms1024m -XX:NewSize=128m"
 ENV OMRS_JAVA_SERVER_OPTS="-Dfile.encoding=UTF-8 -server -Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Djava.awt.headlesslib=true"
 
 # These environment variables are used to create the openmrs-server.properties file, which controls how OpenMRS initializes


### PR DESCRIPTION
Since this image is built for Java 8 and these flags do nothing except produce a warning on Java 8, we might as well remove them (I realize things are different on the 1.x branch)